### PR TITLE
llm-tool-collection-deftool: declare indent, doc-string and support for async tool

### DIFF
--- a/llm-tool-collection.el
+++ b/llm-tool-collection.el
@@ -131,11 +131,13 @@ the tool is defined, it is additionally made available via
 `llm-tool-collection-get-all' and `llm-tool-collection-get-category',
 and all functions in `llm-tool-collection-post-define-functions' are
 called with the tool's spec as their argument."
-  (declare (indent defun)
+  (declare (indent 4)
+           (doc-string 4)
            (debug (&define symbolp sexp sexp stringp def-body)))
   (let* ((optional nil)
          (arg-syms '())
          (arg-specs '()))
+    (when (plist-get specs :async) (push 'callback-fn arg-syms))
     (dolist (arg args)
       (if (eq arg '&optional)
           (progn
@@ -206,25 +208,12 @@ similar will add all tools to the respective client:
   (mapcar #'symbol-value llm-tool-collection--all-tools))
 
 ;;; Imenu
-
-;;;###autoload
 (cl-pushnew (list "LLM Tools"
                   (concat "^\\s-*("
                           (regexp-opt '("llm-tool-collection-deftool") t)
                           "\\s-+\\(" lisp-mode-symbol-regexp "\\)")
                   2)
             lisp-imenu-generic-expression :test #'equal)
-
-;;; Font-Lock
-
-;;;###autoload
-(defconst llm-tool-collection-font-lock-keywords
-  '(("(\\(llm-tool-collection-deftool\\)\\_>[ \t'(]*\\(\\(?:\\sw\\|\\s_\\)+\\)?"
-     (1 'font-lock-keyword-face)
-     (2 'font-lock-function-name-face nil t))))
-
-;;;###autoload
-(font-lock-add-keywords 'emacs-lisp-mode llm-tool-collection-font-lock-keywords)
 
 ;;; Tools
 


### PR DESCRIPTION
Properly declare the indent and doc-string index for `llm-tool-collection-deftool`
Remove some autoload tag and font lock since it will be handled correctly after the `llm-tool-collections` is loaded.
And finally add support for async tool, where the body can take and `callback-fn` to notify the result back in async way to LLM